### PR TITLE
support custom directives on dynamic schemas

### DIFF
--- a/src/dynamic/schema.rs
+++ b/src/dynamic/schema.rs
@@ -6,7 +6,7 @@ use indexmap::IndexMap;
 
 use crate::{
     Data, Executor, IntrospectionMode, QueryEnv, Request, Response, SDLExportOptions, SchemaEnv,
-    ServerError, ServerResult, ValidationMode,
+    ServerError, ServerResult, ValidationMode, CustomDirectiveFactory,
     dynamic::{
         DynamicRequest, FieldFuture, FieldValue, Object, ResolverContext, Scalar, SchemaError,
         Subscription, TypeRef, Union, field::BoxResolverFn, resolve::resolve_container,
@@ -34,6 +34,7 @@ pub struct SchemaBuilder {
     introspection_mode: IntrospectionMode,
     enable_federation: bool,
     entity_resolver: Option<BoxResolverFn>,
+    custom_directives: HashMap<String, Box<dyn CustomDirectiveFactory>>,
 }
 
 impl SchemaBuilder {
@@ -146,6 +147,27 @@ impl SchemaBuilder {
         }
     }
 
+    /// Register a custom directive.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the directive with the same name is already registered.
+    #[must_use]
+    pub fn directive<T: CustomDirectiveFactory>(mut self, directive: T) -> Self {
+        let name = directive.name();
+        let instance = Box::new(directive);
+
+        if self
+            .custom_directives
+            .insert(name.clone().into(), instance)
+            .is_some()
+        {
+            panic!("Directive `{}` already exists", name);
+        }
+
+        self
+    }
+
     /// Consumes this builder and returns a schema.
     pub fn finish(mut self) -> Result<Schema, SchemaError> {
         let mut registry = Registry {
@@ -203,11 +225,16 @@ impl SchemaBuilder {
                 .insert("_Entity".to_string(), Type::Union(entity));
         }
 
+        // Register all custom directives with the registry
+        for (_, directive) in &mut self.custom_directives {
+            directive.register(&mut registry)
+        }
+
         let inner = SchemaInner {
             env: SchemaEnv(Arc::new(SchemaEnvInner {
                 registry,
                 data: self.data,
-                custom_directives: Default::default(),
+                custom_directives: self.custom_directives
             })),
             extensions: self.extensions,
             types: self.types,
@@ -266,6 +293,7 @@ impl Schema {
             introspection_mode: IntrospectionMode::Enabled,
             entity_resolver: None,
             enable_federation: false,
+            custom_directives: Default::default(),
         }
     }
 

--- a/tests/dynamic_schema.rs
+++ b/tests/dynamic_schema.rs
@@ -1,12 +1,15 @@
 #[cfg(feature = "dynamic-schema")]
 mod tests {
     use async_graphql::{
-        Value,
+        Value, CustomDirective, CustomDirectiveFactory, ContextDirective, ServerResult,
+        registry::{Registry, MetaDirective, __DirectiveLocation, MetaInputValue},
         dynamic::{
             Directive, Enum, EnumItem, Field, FieldFuture, InputObject, InputValue, Interface,
             InterfaceField, Object, ResolverContext, Scalar, Schema, SchemaError, TypeRef, Union,
         },
     };
+    use std::borrow::Cow;
+    use indexmap::IndexMap;
 
     fn mock_resolver_fn(_ctx: ResolverContext) -> FieldFuture {
         FieldFuture::Value(None)
@@ -22,7 +25,8 @@ mod tests {
         let interface = Interface::new("TestInterface")
             .field(
                 InterfaceField::new("id", TypeRef::named_nn(TypeRef::STRING))
-                    .directive(Directive::new("id")),
+                    .directive(Directive::new("id"))
+                    .directive(Directive::new("testDirective").argument("prefix", "prefix".into())),
             )
             .field(InterfaceField::new(
                 "name",
@@ -33,7 +37,8 @@ mod tests {
                     .argument("a", Value::from(5))
                     .argument("b", Value::from(true))
                     .argument("c", Value::from("str")),
-            );
+            )
+            .directive(Directive::new("testDirective").argument("prefix", "prefix".into()));
 
         let output_type = Object::new("OutputType")
             .implement(interface.type_name())
@@ -120,6 +125,45 @@ mod tests {
                 mock_resolver_fn,
             ));
 
+        struct TestDirective;
+        impl CustomDirective for TestDirective {}
+        impl CustomDirectiveFactory for TestDirective {
+            fn name(&self) -> Cow<'static, str> {
+                "testDirective".into()
+            }
+
+            fn register(&self, registry: &mut Registry) {
+                registry.add_directive(MetaDirective {
+                    name: "testDirective".to_string(),
+                    description: Some("Concatenates a string".to_string()),
+                    locations: vec![__DirectiveLocation::ARGUMENT_DEFINITION, __DirectiveLocation::OBJECT, __DirectiveLocation::ENUM],
+                    args: {
+                        let mut map = IndexMap::new();
+                        map.insert(String::from("prefix"), MetaInputValue {
+                            name: "prefix".to_string(),
+                            description: None,
+                            ty: "String!".to_string(),
+                            deprecation: Default::default(),
+                            default_value: None,
+                            visible: None,
+                            inaccessible: false,
+                            tags: vec![],
+                            is_secret: false,
+                            directive_invocations: vec![],
+                        });
+                        map
+                    },
+                    is_repeatable: false,
+                    visible: None,
+                    composable: None,
+                })
+            }
+
+            fn create(&self, _: &ContextDirective<'_>, _: &async_graphql_parser::types::Directive) -> ServerResult<Box<dyn CustomDirective>> {
+                Ok(Box::new(TestDirective {}))
+            }
+        }
+
         Schema::build(query.type_name(), None, None)
             .register(test_enum)
             .register(interface)
@@ -129,6 +173,7 @@ mod tests {
             .register(union_type)
             .register(scalar)
             .register(query)
+            .directive(TestDirective)
             .finish()
     }
 

--- a/tests/schemas/test_dynamic_schema.graphql
+++ b/tests/schemas/test_dynamic_schema.graphql
@@ -26,8 +26,8 @@ enum TestEnum @oneOf {
 	C
 }
 
-interface TestInterface @test(a: 5, b: true, c: "str") {
-	id: String! @id
+interface TestInterface @test(a: 5, b: true, c: "str") @testDirective(prefix: "prefix") {
+	id: String! @id @testDirective(prefix: "prefix")
 	name: String!
 }
 
@@ -43,6 +43,10 @@ directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 Directs the executor to skip this field or fragment when the `if` argument is true.
 """
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+"""
+Concatenates a string
+"""
+directive @testDirective(prefix: String!) on ARGUMENT_DEFINITION | OBJECT | ENUM
 schema {
 	query: Query
 }


### PR DESCRIPTION
## Why?

https://github.com/async-graphql/async-graphql/issues/1740

Dynamic SchemaBuilder does not support registration of custom directives. We can **use** directives, and it will be emitted on the relevant target, but the directive's definition will not appear in the GraphQL introspection output, which defeats the purpose

## Solution

Take hints from Static SchemaBuilder and add a `directive()` function to the dynamic builder. Example implementation is in the test: https://github.com/marktabry/async-graphql/pull/3/files#diff-5343e3dddb3777949f153ec92ff1688011be559e4c30dca7abdc8165a7f8a1ebR128-R165

Unlike the macro-based method of defining directives on the Static SchemaBuilder, IMO adding a directive this way is inelegant. Maybe it's my unfamiliarity with Rust, but this is what's happening anyway under the hood of those macros.


## Testing
I added passing test cases to the existing dynamic_schema tests. 
* I couldn't run all tests even on master due to what looks like unrelated errors
* Also, the code compiles, which is a strong signal since this is Rust

I used `graphql-codegen` to dump the introspection result of that schema. The new `testDirective` was exactly where I expected it to be
<img width="1151" height="1365" alt="image" src="https://github.com/user-attachments/assets/45212696-24e9-473b-97b3-8aaadb269274" />
