### PR TITLE
fix: directives incorrectly placed before implements

### DIFF
--- a/src/registry/export_sdl.rs
+++ b/src/registry/export_sdl.rs
@@ -531,11 +531,11 @@ impl Registry {
                     }
                 }
 
+                self.write_implements(sdl, name);
+
                 for directive in directive_invocations {
                     write!(sdl, " {}", directive.sdl()).ok();
                 }
-
-                self.write_implements(sdl, name);
 
                 writeln!(sdl, " {{").ok();
                 Self::export_fields(sdl, fields.values(), options);

--- a/tests/dynamic_schema.rs
+++ b/tests/dynamic_schema.rs
@@ -22,6 +22,11 @@ mod tests {
             .item(EnumItem::new("C"))
             .directive(Directive::new("oneOf"));
 
+        let super_interface = Interface::new("SuperInterface").field(InterfaceField::new(
+            "id",
+            TypeRef::named_nn(TypeRef::STRING),
+        ));
+
         let interface = Interface::new("TestInterface")
             .field(
                 InterfaceField::new("id", TypeRef::named_nn(TypeRef::STRING))
@@ -32,6 +37,7 @@ mod tests {
                 "name",
                 TypeRef::named_nn(TypeRef::STRING),
             ))
+            .implement(super_interface.type_name())
             .directive(
                 Directive::new("test")
                     .argument("a", Value::from(5))
@@ -166,6 +172,7 @@ mod tests {
 
         Schema::build(query.type_name(), None, None)
             .register(test_enum)
+            .register(super_interface)
             .register(interface)
             .register(input_type)
             .register(output_type)

--- a/tests/schemas/test_dynamic_schema.graphql
+++ b/tests/schemas/test_dynamic_schema.graphql
@@ -20,13 +20,17 @@ type Query {
 	scalar: TestScalar
 }
 
+interface SuperInterface {
+	id: String!
+}
+
 enum TestEnum @oneOf {
 	A
 	B @default
 	C
 }
 
-interface TestInterface @test(a: 5, b: true, c: "str") @testDirective(prefix: "prefix") {
+interface TestInterface implements SuperInterface @test(a: 5, b: true, c: "str") @testDirective(prefix: "prefix") {
 	id: String! @id @testDirective(prefix: "prefix")
 	name: String!
 }


### PR DESCRIPTION
The GraphQL spec is very clear about the order of directives in a definition - they come after implements. https://spec.graphql.org/October2021/#sec-Interfaces

It seems this is not strictly enforced by all parsers, such as graphql-codegen, which works fine when mis-ordered. Others like graphql-inspector are strict and error when mis-ordered.

This was already correct for Objects but not Interfaces.

Tested by `cargo test --test dynamic_schema --features "dynamic-schema"`